### PR TITLE
remove space from url

### DIFF
--- a/src/arcgis_tiled_map_service_source.js
+++ b/src/arcgis_tiled_map_service_source.js
@@ -70,7 +70,7 @@ class ArcGISTiledMapServiceSource extends Evented {
     onAdd(map) {
         // set the urls
         const baseUrl = this.url.split('?')[0];
-        this.tileUrl = `${baseUrl} /tile/{z}/{y}/{x}`;
+        this.tileUrl = `${baseUrl}/tile/{z}/{y}/{x}`;
 
         const arcgisonline = new RegExp(/tiles.arcgis(online)?\.com/g);
         if (arcgisonline.test(this.url)) {


### PR DESCRIPTION
I was getting 404s due to a space (%20) being added to request urls. 
ex: 
https://arcgis.dnr.state.mn.us/arcgis/rest/services/elevation/mn_hillshade_web_mercator/MapServer%20/tile/7/2874/1998
where it should be 
https://arcgis.dnr.state.mn.us/arcgis/rest/services/elevation/mn_hillshade_web_mercator/MapServer/tile/7/2874/1998
(no %20)

Thanks so much for making this project available!  
